### PR TITLE
Opt-out from HTTP / gRPC APIs when building binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RCS
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/nmezhenskyi/rcs)](https://goreportcard.com/report/github.com/nmezhenskyi/rcs)
+![Build Workflow](https://github.com/nmezhenskyi/rcs/actions/workflows/go.yml/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/nmezhenskyi/rcs/blob/main/LICENSE.md)
 
 RCS, which stands for Remote Caching Server, is an in-memory key-value data store written in Go.

--- a/internal/grpcsrv/grpc.go
+++ b/internal/grpcsrv/grpc.go
@@ -1,3 +1,5 @@
+//go:build !rmgrpc
+
 // Package grpcsrv implements gRPC server.
 //
 // See Protobuf specification at https://github.com/nmezhenskyi/rcs/blob/main/api/protobuf/rcs.proto.
@@ -30,7 +32,7 @@ type Server struct {
 }
 
 // NewServer initializes a new grpc Server instance ready to be used and returns a pointer to it.
-// You can also attach a Logger to return Server by accessing public field Server.Logger.
+// A zerolog.Logger can be attached to returned Server by accessing public field Server.Logger.
 func NewServer(c *cache.CacheMap, opts ...grpc.ServerOption) *Server {
 	if c == nil {
 		c = cache.NewCacheMap()

--- a/internal/grpcsrv/grpc_stub.go
+++ b/internal/grpcsrv/grpc_stub.go
@@ -1,0 +1,34 @@
+//go:build rmgrpc
+
+package grpcsrv
+
+import (
+	"context"
+
+	"github.com/nmezhenskyi/rcs/internal/cache"
+	"github.com/rs/zerolog"
+)
+
+type Server struct {
+	Logger zerolog.Logger
+}
+
+func NewServer(_ *cache.CacheMap) *Server {
+	return &Server{}
+}
+
+func (s *Server) ListenAndServe(addr string) error {
+	return nil
+}
+
+func (s *Server) ListenAndServeTLS(addr, certFile, keyFile string) error {
+	return nil
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+func (s *Server) Close(ctx context.Context) error {
+	return nil
+}

--- a/internal/grpcsrv/grpc_test.go
+++ b/internal/grpcsrv/grpc_test.go
@@ -1,3 +1,5 @@
+//go:build !rmgrpc
+
 package grpcsrv
 
 import (

--- a/internal/httpsrv/http.go
+++ b/internal/httpsrv/http.go
@@ -1,3 +1,5 @@
+//go:build !rmhttp
+
 // Package httpsrv implements HTTP server that uses JSON payloads for data communication.
 //
 // See OpenAPI specification at https://github.com/nmezhenskyi/rcs/blob/main/api/openapi/rcs.yaml.

--- a/internal/httpsrv/http_stub.go
+++ b/internal/httpsrv/http_stub.go
@@ -1,0 +1,34 @@
+//go:build rmhttp
+
+package httpsrv
+
+import (
+	"context"
+
+	"github.com/nmezhenskyi/rcs/internal/cache"
+	"github.com/rs/zerolog"
+)
+
+type Server struct {
+	Logger zerolog.Logger
+}
+
+func NewServer(_ *cache.CacheMap) *Server {
+	return &Server{}
+}
+
+func (s *Server) ListenAndServe(addr string) error {
+	return nil
+}
+
+func (s *Server) ListenAndServeTLS(addr, certFile, keyFile string) error {
+	return nil
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+func (s *Server) Close(ctx context.Context) error {
+	return nil
+}

--- a/internal/httpsrv/http_test.go
+++ b/internal/httpsrv/http_test.go
@@ -1,3 +1,5 @@
+//go:build !rmhttp
+
 package httpsrv
 
 import (


### PR DESCRIPTION
## Features

Added ability to opt-out from HTTP / gRPC APIs when building binary by using build tags:
 - `rmgrpc` - to remove grpc API and related dependencies from the binary
 - `rmhttp` - to remove http API and related dependencies from the binary

Example: `go build -tags "rmgrpc rmhttp" -o ./bin/rcs ./cmd`