### PR TITLE
Implement item struct, refactor CacheMap to store item structs

### DIFF
--- a/internal/cache/item.go
+++ b/internal/cache/item.go
@@ -1,4 +1,16 @@
 package cache
 
-type Item struct {
+import "time"
+
+// item represents a value stored in cache, it may have an expiration date.
+type item struct {
+	data    []byte
+	expires int64 // if zero, item never expires.
+}
+
+func (i *item) isExpired() bool {
+	if i.expires == 0 {
+		return false
+	}
+	return time.Now().UnixNano() > i.expires
 }

--- a/internal/cache/item_test.go
+++ b/internal/cache/item_test.go
@@ -1,0 +1,43 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestItemIsExpired(t *testing.T) {
+	testCases := []struct {
+		name     string
+		i        item
+		expected bool
+	}{
+		{
+			name:     "Zero expiration value",
+			i:        item{[]byte(""), 0},
+			expected: false,
+		},
+		{
+			name:     "Negative expiration value",
+			i:        item{[]byte(""), -100},
+			expected: true,
+		},
+		{
+			name:     "Expired",
+			i:        item{[]byte(""), time.Now().UnixNano() - 100000},
+			expected: true,
+		},
+		{
+			name:     "Not expired",
+			i:        item{[]byte(""), time.Now().UnixNano() + 100000},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.i.isExpired() != tc.expected {
+				t.Errorf("Expected %v, got %v instead", tc.expected, tc.i.isExpired())
+			}
+		})
+	}
+}

--- a/internal/cache/map_test.go
+++ b/internal/cache/map_test.go
@@ -26,7 +26,7 @@ func TestSet(t *testing.T) {
 	if !ok {
 		t.Error("Key has not been set")
 	}
-	if bytes.Compare(retrieved, value) != 0 {
+	if bytes.Compare(retrieved.data, value) != 0 {
 		t.Error("Retrieved value is not the same")
 	}
 
@@ -51,7 +51,7 @@ func TestGet(t *testing.T) {
 		t.Errorf("Found nonexistent key")
 	}
 
-	cmap.items = map[string][]byte{key: value}
+	cmap.items = map[string]item{key: {data: value}}
 	retrieved, ok := cmap.Get(key)
 	if !ok {
 		t.Error("Key not found")
@@ -63,12 +63,12 @@ func TestGet(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	cmap := NewCacheMap()
-	cmap.items = map[string][]byte{
-		"key1": []byte("value1"),
-		"key2": []byte("value2"),
-		"key3": []byte("value3"),
-		"key4": []byte("value4"),
-		"key5": []byte("value5"),
+	cmap.items = map[string]item{
+		"key1": {data: []byte("value1")},
+		"key2": {data: []byte("value2")},
+		"key3": {data: []byte("value3")},
+		"key4": {data: []byte("value4")},
+		"key5": {data: []byte("value5")},
 	}
 
 	cmap.Delete("key2")
@@ -81,12 +81,12 @@ func TestDelete(t *testing.T) {
 
 func TestPurge(t *testing.T) {
 	cmap := NewCacheMap()
-	cmap.items = map[string][]byte{
-		"key1": []byte("value1"),
-		"key2": []byte("value2"),
-		"key3": []byte("value3"),
-		"key4": []byte("value4"),
-		"key5": []byte("value5"),
+	cmap.items = map[string]item{
+		"key1": {data: []byte("value1")},
+		"key2": {data: []byte("value2")},
+		"key3": {data: []byte("value3")},
+		"key4": {data: []byte("value4")},
+		"key5": {data: []byte("value5")},
 	}
 
 	cmap.Purge()
@@ -97,12 +97,12 @@ func TestPurge(t *testing.T) {
 
 func TestLength(t *testing.T) {
 	cmap := NewCacheMap()
-	cmap.items = map[string][]byte{
-		"key1": []byte("value1"),
-		"key2": []byte("value2"),
-		"key3": []byte("value3"),
-		"key4": []byte("value4"),
-		"key5": []byte("value5"),
+	cmap.items = map[string]item{
+		"key1": {data: []byte("value1")},
+		"key2": {data: []byte("value2")},
+		"key3": {data: []byte("value3")},
+		"key4": {data: []byte("value4")},
+		"key5": {data: []byte("value5")},
 	}
 
 	length := cmap.Length()
@@ -113,12 +113,12 @@ func TestLength(t *testing.T) {
 
 func TestKeys(t *testing.T) {
 	cmap := NewCacheMap()
-	cmap.items = map[string][]byte{
-		"key1": []byte("value1"),
-		"key2": []byte("value2"),
-		"key3": []byte("value3"),
-		"key4": []byte("value4"),
-		"key5": []byte("value5"),
+	cmap.items = map[string]item{
+		"key1": {data: []byte("value1")},
+		"key2": {data: []byte("value2")},
+		"key3": {data: []byte("value3")},
+		"key4": {data: []byte("value4")},
+		"key5": {data: []byte("value5")},
 	}
 	expectedKeys := []string{"key1", "key2", "key3", "key4", "key5"}
 


### PR DESCRIPTION
## Changes

- Implement item struct.
- Refactor CacheMap to store item structs instead of byte slices.