### PR TITLE
Simple Cache cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
-.PHONY: build dev run test tidy clean cleanproto cleanall
+.PHONY: build genproto dev run test tidy clean cleanproto cleanall
 
 PROTO_IN_DIR := api/protobuf
 PROTO_OUT_DIR := internal/genproto
 PROTOS := $(wildcard $(PROTO_IN_DIR)/*.proto)
 
-genproto: $(PROTOS)
-	mkdir -p $(PROTO_OUT_DIR)
+$(PROTO_OUT_DIR): $(PROTOS)
+	mkdir -p $@
 	protoc --proto_path=$(PROTO_IN_DIR) \
-		--go_out=$(PROTO_OUT_DIR) --go_opt=paths=source_relative \
-		--go-grpc_out=$(PROTO_OUT_DIR) --go-grpc_opt=paths=source_relative \
+		--go_out=$@ --go_opt=paths=source_relative \
+		--go-grpc_out=$@ --go-grpc_opt=paths=source_relative \
 		$(PROTOS)
 
-build: genproto
+build: $(PROTO_OUT_DIR)
 	go build -o ./bin/rcs ./cmd
+
+genproto: $(PROTO_OUT_DIR)
 
 dev:
 	go run ./cmd
@@ -30,7 +32,7 @@ clean:
 	-@rm -r ./bin 2>/dev/null || true
 
 cleanproto:
-	-@rm -r ./internal/genproto 2>/dev/null || true
+	-@rm -r $(PROTO_OUT_DIR) 2>/dev/null || true
 
 cleanall: clean cleanproto
 

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,37 @@
-.PHONY: build
-build:
+.PHONY: build dev run test tidy clean cleanproto cleanall
+
+PROTO_IN_DIR := api/protobuf
+PROTO_OUT_DIR := internal/genproto
+PROTOS := $(wildcard $(PROTO_IN_DIR)/*.proto)
+
+genproto: $(PROTOS)
+	mkdir -p $(PROTO_OUT_DIR)
+	protoc --proto_path=$(PROTO_IN_DIR) \
+		--go_out=$(PROTO_OUT_DIR) --go_opt=paths=source_relative \
+		--go-grpc_out=$(PROTO_OUT_DIR) --go-grpc_opt=paths=source_relative \
+		$(PROTOS)
+
+build: genproto
 	go build -o ./bin/rcs ./cmd
 
-.PHONY: genproto
-genproto:
-	mkdir -p internal/genproto
-	protoc --proto_path=api/protobuf \
-		--go_out=internal/genproto --go_opt=paths=source_relative \
-		--go-grpc_out=internal/genproto --go-grpc_opt=paths=source_relative \
-		rcs.proto
-
-.PHONY: dev
 dev:
 	go run ./cmd
 
-.PHONY: run
-run:
+run: build
 	./bin/rcs
 
-.PHONY: test
 test:
 	go test ./internal/**
 
-.PHONY: tidy
 tidy:
 	go mod tidy
 
-.PHONY: clean
 clean:
 	-@rm -r ./bin 2>/dev/null || true
 
-.PHONY: cleanproto
 cleanproto:
 	-@rm -r ./internal/genproto 2>/dev/null || true
 
-.PHONY: cleanall
 cleanall: clean cleanproto
 
-.PHONY: setup
-setup: genproto build
-
-.PHONY: compile
-compile: build run
-
-.DEFAULT_GOAL := compile
+.DEFAULT_GOAL := run

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Steps:
 Alternatively if you have Make installed:
 
 1. Clone the repository: `git clone https://github.com/nmezhenskyi/rcs.git`.
-2. Run `make setup` command. This will generate protobuf and grpc files, build the project,
+2. Run `make build` command. This will generate protobuf and grpc files, build the project,
 and create the binary in the `./bin` directory.
 
 ### Run

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/nmezhenskyi/rcs
 
-go 1.18
+go 1.19
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/rs/zerolog v1.27.0
-	google.golang.org/grpc v1.48.0
+	github.com/rs/zerolog v1.28.0
+	google.golang.org/grpc v1.51.0
 	google.golang.org/protobuf v1.28.1
 )
 
@@ -13,8 +13,8 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
-	golang.org/x/net v0.0.0-20220812174116-3211cb980234 // indirect
-	golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 // indirect
-	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/genproto v0.0.0-20220819174105-e9f053255caa // indirect
+	golang.org/x/net v0.2.0 // indirect
+	golang.org/x/sys v0.2.0 // indirect
+	golang.org/x/text v0.4.0 // indirect
+	google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,11 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.27.0 h1:1T7qCieN22GVc8S4Q2yuexzBb1EqjbgjSH9RohbMjKs=
 github.com/rs/zerolog v1.27.0/go.mod h1:7frBqO0oezxmnO7GF86FY++uy8I0Tk/If5ni1G9Qc0U=
+github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
+github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -82,6 +85,8 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20220812174116-3211cb980234 h1:RDqmgfe7SvlMWoqC3xwQ2blLO3fcWcxMa3eBLRdRW7E=
 golang.org/x/net v0.0.0-20220812174116-3211cb980234/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.2.0 h1:sZfSu1wtKLGlWI4ZZayP0ck9Y73K1ynO6gqzTdBVdPU=
+golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -99,10 +104,14 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 h1:Sx/u41w+OwrInGdEckYmEuU5gHoGSL4QbDz3S9s6j4U=
 golang.org/x/sys v0.0.0-20220818161305-2296e01440c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
+golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
@@ -119,6 +128,8 @@ google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20220819174105-e9f053255caa h1:Ux9yJCyf598uEniFPSyp8g1jtGTt77m+lzYyVgrWQaQ=
 google.golang.org/genproto v0.0.0-20220819174105-e9f053255caa/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
+google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6 h1:a2S6M0+660BgMNl++4JPlcAO/CjkqYItDEZwkoDQK7c=
+google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
@@ -127,6 +138,8 @@ google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTp
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.48.0 h1:rQOsyJ/8+ufEDJd/Gdsz7HG220Mh9HAhFHRGnIjda0w=
 google.golang.org/grpc v1.48.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
+google.golang.org/grpc v1.51.0 h1:E1eGv1FTqoLIdnBCZufiSHgKjlqG6fKFf6pPWtMTh8U=
+google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsAIPww=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/internal/cache/map.go
+++ b/internal/cache/map.go
@@ -1,3 +1,4 @@
+// Package cache contains all internal cache implementations for RCS.
 package cache
 
 import "sync"
@@ -14,10 +15,18 @@ func NewCacheMap() *CacheMap {
 	return &CacheMap{items: make(map[string]item)}
 }
 
-// Set sets given value for the given key, possible overwriting it.
+// Set sets given value for the given key, possibly overwriting it.
 func (cm *CacheMap) Set(key string, value []byte) {
 	cm.mu.Lock()
 	cm.items[key] = item{data: value}
+	cm.mu.Unlock()
+}
+
+// SetEx sets given value for the given key, and an expiration time.
+// Overwrites the previous value for the key.
+func (cm *CacheMap) SetEx(key string, value []byte, expires int64) {
+	cm.mu.Lock()
+	cm.items[key] = item{data: value, expires: expires}
 	cm.mu.Unlock()
 }
 

--- a/internal/cache/map.go
+++ b/internal/cache/map.go
@@ -1,18 +1,36 @@
 // Package cache contains all internal cache implementations for RCS.
 package cache
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
 
 // CacheMap represents in-memory key-value table safe for concurrent usage.
 // Uses strings as keys. Stores items with byte slices and expiration time.
 type CacheMap struct {
+	cleanupInterval time.Duration
+	stop            chan struct{}
+
 	mu    sync.RWMutex
 	items map[string]item
 }
 
-// NewCacheMap returns pointer to initialized CacheMap.
+// NewCacheMap returns pointer to initialized CacheMap without cleanup routine.
 func NewCacheMap() *CacheMap {
 	return &CacheMap{items: make(map[string]item)}
+}
+
+// NewCacheMap returns pointer to initialized CacheMap with cleanup routine.
+func NewCacheMapWithCleanup(interval time.Duration) *CacheMap {
+	c := &CacheMap{
+		cleanupInterval: interval,
+		items:           make(map[string]item),
+	}
+	if c.cleanupInterval > 0 {
+		go c.startCleanup()
+	}
+	return c
 }
 
 // Set sets given value for the given key, possibly overwriting it.
@@ -36,6 +54,9 @@ func (cm *CacheMap) Get(key string) ([]byte, bool) {
 	cm.mu.RLock()
 	value, ok := cm.items[key]
 	cm.mu.RUnlock()
+	if value.isExpired() {
+		return nil, false
+	}
 	return value.data, ok
 }
 
@@ -73,4 +94,36 @@ func (cm *CacheMap) Keys() []string {
 	}
 	cm.mu.RUnlock()
 	return keys
+}
+
+func (cm *CacheMap) StopCleanup() {
+	if cm.stop != nil {
+		cm.stop <- struct{}{}
+	}
+}
+
+func (cm *CacheMap) startCleanup() {
+	cm.stop = make(chan struct{})
+
+	ticker := time.NewTicker(cm.cleanupInterval)
+	for {
+		select {
+		case <-ticker.C:
+			cm.deleteExpired()
+		case <-cm.stop:
+			ticker.Stop()
+			cm.stop = nil
+			return
+		}
+	}
+}
+
+func (cm *CacheMap) deleteExpired() {
+	cm.mu.Lock()
+	for k, v := range cm.items {
+		if v.isExpired() {
+			delete(cm.items, k)
+		}
+	}
+	cm.mu.Unlock()
 }

--- a/internal/cache/map_test.go
+++ b/internal/cache/map_test.go
@@ -11,7 +11,7 @@ func TestNewCacheMap(t *testing.T) {
 	if cmap == nil {
 		t.Error("Expected pointer to initialized CacheMap, got nil instead")
 	}
-	if cmap.items == nil {
+	if cmap != nil && cmap.items == nil {
 		t.Error("CacheMap.items field is nil")
 	}
 }
@@ -26,7 +26,7 @@ func TestSet(t *testing.T) {
 	if !ok {
 		t.Error("Key has not been set")
 	}
-	if bytes.Compare(retrieved.data, value) != 0 {
+	if !bytes.Equal(retrieved.data, value) {
 		t.Error("Retrieved value is not the same")
 	}
 
@@ -38,6 +38,25 @@ func TestSet(t *testing.T) {
 
 	if len(cmap.items) != 5 {
 		t.Errorf("Expected 5 keys, but got %d", len(cmap.items))
+	}
+}
+
+func TestSetEx(t *testing.T) {
+	cmap := NewCacheMap()
+	key := "key1"
+	value := []byte("value1")
+	expires := int64(1668819947000)
+	cmap.SetEx(key, value, expires)
+
+	retrieved, ok := cmap.items[key]
+	if !ok {
+		t.Error("Key has not been set")
+	}
+	if !bytes.Equal(retrieved.data, value) {
+		t.Error("Retrieved value is not the same")
+	}
+	if retrieved.expires != expires {
+		t.Error("Stored expires time does not match the given value")
 	}
 }
 
@@ -56,7 +75,7 @@ func TestGet(t *testing.T) {
 	if !ok {
 		t.Error("Key not found")
 	}
-	if bytes.Compare(retrieved, value) != 0 {
+	if !bytes.Equal(retrieved, value) {
 		t.Error("Retrieved value is not the same")
 	}
 }

--- a/internal/grpcsrv/grpc.go
+++ b/internal/grpcsrv/grpc.go
@@ -74,12 +74,12 @@ func (s *Server) ListenAndServeTLS(addr, certFile, keyFile string) error {
 	s.opts = append(s.opts, grpc.Creds(creds))
 	s.server = grpc.NewServer(s.opts...)
 	pb.RegisterCacheServiceServer(s.server, s)
-	listener, err := net.Listen("tcp", addr)
+	lis, err := net.Listen("tcp", addr)
 	if err != nil {
 		s.Logger.Error().Err(err).Msg("failed to start tls listener")
 		return err
 	}
-	return s.server.Serve(listener)
+	return s.server.Serve(lis)
 }
 
 // Shutdown gracefully shuts down the server without interrupting any

--- a/internal/grpcsrv/grpc_test.go
+++ b/internal/grpcsrv/grpc_test.go
@@ -18,7 +18,7 @@ func TestNewServer(t *testing.T) {
 	if server == nil {
 		t.Error("Expected pointer to initialized Server, got nil instead")
 	}
-	if server.cache == nil {
+	if server != nil && server.cache == nil {
 		t.Error("Server.cache has not been initialized")
 	}
 }
@@ -120,7 +120,7 @@ func TestGet(t *testing.T) {
 			if reply.Key != tc.key {
 				t.Errorf("Expected key \"%s\", got \"%s\" instead", tc.key, reply.Key)
 			}
-			if bytes.Compare(reply.Value, tc.value) != 0 {
+			if !bytes.Equal(reply.Value, tc.value) {
 				t.Errorf("Expected value to be %v, got %v instead", tc.value, reply.Value)
 			}
 		})

--- a/internal/nativesrv/messages.go
+++ b/internal/nativesrv/messages.go
@@ -52,7 +52,7 @@ func parseRequest(msg []byte) (request, error) {
 	}
 	msgLines[linesCount-1] = bytes.TrimSuffix(msgLines[linesCount-1], []byte("\r\n"))
 	headerTokens := bytes.Split(msgLines[0], []byte(" "))
-	if len(headerTokens) != 2 || bytes.Compare(headerTokens[0], []byte("RCSP/1.0")) != 0 {
+	if len(headerTokens) != 2 || !bytes.Equal(headerTokens[0], []byte("RCSP/1.0")) {
 		return request{}, ErrUnknownProtocol
 	}
 
@@ -68,7 +68,7 @@ func parseRequest(msg []byte) (request, error) {
 		keyTokens := bytes.SplitN(msgLines[1], []byte(": "), 2)
 		if len(keyTokens) != 2 {
 			encounteredErr = ErrInvalidKey
-		} else if bytes.Compare(keyTokens[0], []byte("KEY")) != 0 {
+		} else if !bytes.Equal(keyTokens[0], []byte("KEY")) {
 			encounteredErr = ErrMalformedRequest
 		} else {
 			parsedReq.key = keyTokens[1]
@@ -77,7 +77,7 @@ func parseRequest(msg []byte) (request, error) {
 	// Parse Value:
 	if linesCount > 2 {
 		valueTokens := bytes.SplitN(msgLines[2], []byte(": "), 2)
-		if len(valueTokens) != 2 || bytes.Compare(valueTokens[0], []byte("VALUE")) != 0 {
+		if len(valueTokens) != 2 || !bytes.Equal(valueTokens[0], []byte("VALUE")) {
 			encounteredErr = ErrMalformedRequest
 		} else {
 			parsedReq.value = valueTokens[1]
@@ -158,7 +158,7 @@ func parseResponse(msg []byte) (response, error) {
 	if len(headerTokens) < 2 {
 		return response{}, ErrMalformedResponse
 	}
-	if bytes.Compare(headerTokens[0], []byte("RCSP/1.0")) != 0 {
+	if !bytes.Equal(headerTokens[0], []byte("RCSP/1.0")) {
 		return response{}, ErrUnknownProtocol
 	}
 
@@ -176,9 +176,9 @@ func parseResponse(msg []byte) (response, error) {
 	} else {
 		return response{}, ErrMalformedResponse
 	}
-	if bytes.Compare(headerTokens[okTokenIndex], []byte("OK")) == 0 {
+	if bytes.Equal(headerTokens[okTokenIndex], []byte("OK")) {
 		parsedResp.ok = true
-	} else if bytes.Compare(headerTokens[okTokenIndex], []byte("NOT_OK")) != 0 {
+	} else if !bytes.Equal(headerTokens[okTokenIndex], []byte("NOT_OK")) {
 		encounteredErr = ErrMalformedResponse
 	}
 

--- a/internal/nativesrv/messages_test.go
+++ b/internal/nativesrv/messages_test.go
@@ -119,15 +119,15 @@ func TestParseRequest(t *testing.T) {
 				t.Errorf("Expected error value \"%v\", got \"%v\" instead",
 					tc.expectedErr, err)
 			}
-			if bytes.Compare(req.command, tc.expectedReq.command) != 0 {
+			if !bytes.Equal(req.command, tc.expectedReq.command) {
 				t.Errorf("Expected command \"%s\", got \"%s\" instead",
 					string(tc.expectedReq.command), string(req.command))
 			}
-			if bytes.Compare(req.key, tc.expectedReq.key) != 0 {
+			if !bytes.Equal(req.key, tc.expectedReq.key) {
 				t.Errorf("Expected key \"%s\", got \"%s\" instead",
 					string(tc.expectedReq.key), string(req.key))
 			}
-			if bytes.Compare(req.value, tc.expectedReq.value) != 0 {
+			if !bytes.Equal(req.value, tc.expectedReq.value) {
 				t.Errorf("Expected value \"%s\", got \"%s\" instead",
 					string(tc.expectedReq.value), string(req.value))
 			}
@@ -253,7 +253,7 @@ func TestParseResponse(t *testing.T) {
 				t.Errorf("Expected error value \"%v\", got \"%v\" instead",
 					tc.expectedErr, err)
 			}
-			if bytes.Compare(resp.command, tc.expectedResp.command) != 0 {
+			if !bytes.Equal(resp.command, tc.expectedResp.command) {
 				t.Errorf("Expected command \"%s\", got \"%s\" instead",
 					string(tc.expectedResp.command), string(resp.command))
 			}
@@ -261,15 +261,15 @@ func TestParseResponse(t *testing.T) {
 				t.Errorf("Expected ok to be \"%v\", got \"%v\" instead",
 					tc.expectedResp.ok, resp.ok)
 			}
-			if bytes.Compare(resp.message, tc.expectedResp.message) != 0 {
+			if !bytes.Equal(resp.message, tc.expectedResp.message) {
 				t.Errorf("Expected message \"%s\", got \"%s\" instead",
 					string(tc.expectedResp.message), string(resp.message))
 			}
-			if bytes.Compare(resp.key, tc.expectedResp.key) != 0 {
+			if !bytes.Equal(resp.key, tc.expectedResp.key) {
 				t.Errorf("Expected key \"%s\", got \"%s\" instead",
 					string(tc.expectedResp.key), string(resp.key))
 			}
-			if bytes.Compare(resp.value, tc.expectedResp.value) != 0 {
+			if !bytes.Equal(resp.value, tc.expectedResp.value) {
 				t.Errorf("Expected value \"%s\", got \"%s\" instead",
 					string(tc.expectedResp.value), string(resp.value))
 			}

--- a/internal/nativesrv/native_test.go
+++ b/internal/nativesrv/native_test.go
@@ -15,7 +15,7 @@ func TestNewServer(t *testing.T) {
 	if server == nil {
 		t.Error("Expected pointer to initialized Server, got nil instead")
 	}
-	if server.cache == nil {
+	if server != nil && server.cache == nil {
 		t.Error("Server.cache has not been initialized")
 	}
 }
@@ -30,6 +30,7 @@ func TestSet(t *testing.T) {
 	}()
 	defer server.Close()
 
+	time.Sleep(500 * time.Millisecond)
 	testCases := []struct {
 		name             string
 		key              []byte
@@ -128,19 +129,19 @@ func TestSet(t *testing.T) {
 				t.Errorf("Expected ok to be \"%v\", got \"%v\" instead",
 					tc.expectedResponse.ok, resp.ok)
 			}
-			if bytes.Compare(resp.command, tc.expectedResponse.command) != 0 {
+			if !bytes.Equal(resp.command, tc.expectedResponse.command) {
 				t.Errorf("Expected command to be \"%s\", got \"%s\" instead",
 					string(tc.expectedResponse.command), string(resp.command))
 			}
-			if bytes.Compare(resp.message, tc.expectedResponse.message) != 0 {
+			if !bytes.Equal(resp.message, tc.expectedResponse.message) {
 				t.Errorf("Expected message to be \"%s\", got \"%s\" instead",
 					string(tc.expectedResponse.message), string(resp.message))
 			}
-			if bytes.Compare(resp.key, tc.expectedResponse.key) != 0 {
+			if !bytes.Equal(resp.key, tc.expectedResponse.key) {
 				t.Errorf("Expected key to be \"%s\", got \"%s\" instead",
 					string(tc.expectedResponse.key), string(resp.key))
 			}
-			if bytes.Compare(resp.value, tc.expectedResponse.value) != 0 {
+			if !bytes.Equal(resp.value, tc.expectedResponse.value) {
 				t.Errorf("Expected value to be \"%s\", got \"%s\" instead",
 					string(tc.expectedResponse.value), string(resp.value))
 			}
@@ -150,7 +151,7 @@ func TestSet(t *testing.T) {
 				if !ok {
 					t.Error("Value is missing in Server.cache")
 				}
-				if bytes.Compare(req.value, valInCache) != 0 {
+				if !bytes.Equal(req.value, valInCache) {
 					t.Errorf("Expected value in Server.cache to be \"%s\", got \"%s\" instead",
 						string(req.value), string(valInCache))
 				}
@@ -169,6 +170,7 @@ func TestGet(t *testing.T) {
 	}()
 	defer server.Close()
 
+	time.Sleep(500 * time.Millisecond)
 	testCases := []struct {
 		name             string
 		key              []byte
@@ -253,19 +255,19 @@ func TestGet(t *testing.T) {
 				t.Errorf("Expected ok to be \"%v\", got \"%v\" instead",
 					tc.expectedResponse.ok, resp.ok)
 			}
-			if bytes.Compare(resp.command, tc.expectedResponse.command) != 0 {
+			if !bytes.Equal(resp.command, tc.expectedResponse.command) {
 				t.Errorf("Expected command to be \"%s\", got \"%s\" instead",
 					string(tc.expectedResponse.command), string(resp.command))
 			}
-			if bytes.Compare(resp.message, tc.expectedResponse.message) != 0 {
+			if !bytes.Equal(resp.message, tc.expectedResponse.message) {
 				t.Errorf("Expected message to be \"%s\", got \"%s\" instead",
 					string(tc.expectedResponse.message), string(resp.message))
 			}
-			if bytes.Compare(resp.key, tc.expectedResponse.key) != 0 {
+			if !bytes.Equal(resp.key, tc.expectedResponse.key) {
 				t.Errorf("Expected key to be \"%s\", got \"%s\" instead",
 					string(tc.expectedResponse.key), string(resp.key))
 			}
-			if bytes.Compare(resp.value, tc.expectedResponse.value) != 0 {
+			if !bytes.Equal(resp.value, tc.expectedResponse.value) {
 				t.Errorf("Expected value to be \"%s\", got \"%s\" instead",
 					string(tc.expectedResponse.value), string(resp.value))
 			}
@@ -283,6 +285,7 @@ func TestDelete(t *testing.T) {
 	}()
 	defer server.Close()
 
+	time.Sleep(500 * time.Millisecond)
 	testCases := []struct {
 		name             string
 		key              []byte
@@ -355,19 +358,19 @@ func TestDelete(t *testing.T) {
 				t.Errorf("Expected ok to be \"%v\", got \"%v\" instead",
 					tc.expectedResponse.ok, resp.ok)
 			}
-			if bytes.Compare(resp.command, tc.expectedResponse.command) != 0 {
+			if !bytes.Equal(resp.command, tc.expectedResponse.command) {
 				t.Errorf("Expected command to be \"%s\", got \"%s\" instead",
 					string(tc.expectedResponse.command), string(resp.command))
 			}
-			if bytes.Compare(resp.message, tc.expectedResponse.message) != 0 {
+			if !bytes.Equal(resp.message, tc.expectedResponse.message) {
 				t.Errorf("Expected message to be \"%s\", got \"%s\" instead",
 					string(tc.expectedResponse.message), string(resp.message))
 			}
-			if bytes.Compare(resp.key, tc.expectedResponse.key) != 0 {
+			if !bytes.Equal(resp.key, tc.expectedResponse.key) {
 				t.Errorf("Expected key to be \"%s\", got \"%s\" instead",
 					string(tc.expectedResponse.key), string(resp.key))
 			}
-			if bytes.Compare(resp.value, tc.expectedResponse.value) != 0 {
+			if !bytes.Equal(resp.value, tc.expectedResponse.value) {
 				t.Errorf("Expected value to be \"%s\", got \"%s\" instead",
 					string(tc.expectedResponse.value), string(resp.value))
 			}
@@ -387,6 +390,8 @@ func TestPurge(t *testing.T) {
 		}
 	}()
 	defer server.Close()
+
+	time.Sleep(500 * time.Millisecond)
 
 	expectedResponse := response{
 		command: []byte("PURGE"),
@@ -422,19 +427,19 @@ func TestPurge(t *testing.T) {
 		t.Errorf("Expected ok to be \"%v\", got \"%v\" instead",
 			expectedResponse.ok, resp.ok)
 	}
-	if bytes.Compare(resp.command, expectedResponse.command) != 0 {
+	if !bytes.Equal(resp.command, expectedResponse.command) {
 		t.Errorf("Expected command to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.command), string(resp.command))
 	}
-	if bytes.Compare(resp.message, expectedResponse.message) != 0 {
+	if !bytes.Equal(resp.message, expectedResponse.message) {
 		t.Errorf("Expected message to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.message), string(resp.message))
 	}
-	if bytes.Compare(resp.key, expectedResponse.key) != 0 {
+	if !bytes.Equal(resp.key, expectedResponse.key) {
 		t.Errorf("Expected key to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.key), string(resp.key))
 	}
-	if bytes.Compare(resp.value, expectedResponse.value) != 0 {
+	if !bytes.Equal(resp.value, expectedResponse.value) {
 		t.Errorf("Expected value to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.value), string(resp.value))
 	}
@@ -452,6 +457,8 @@ func TestLength(t *testing.T) {
 		}
 	}()
 	defer server.Close()
+
+	time.Sleep(500 * time.Millisecond)
 
 	expectedResponse := response{
 		command: []byte("LENGTH"),
@@ -489,19 +496,19 @@ func TestLength(t *testing.T) {
 		t.Errorf("Expected ok to be \"%v\", got \"%v\" instead",
 			expectedResponse.ok, resp.ok)
 	}
-	if bytes.Compare(resp.command, expectedResponse.command) != 0 {
+	if !bytes.Equal(resp.command, expectedResponse.command) {
 		t.Errorf("Expected command to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.command), string(resp.command))
 	}
-	if bytes.Compare(resp.message, expectedResponse.message) != 0 {
+	if !bytes.Equal(resp.message, expectedResponse.message) {
 		t.Errorf("Expected message to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.message), string(resp.message))
 	}
-	if bytes.Compare(resp.key, expectedResponse.key) != 0 {
+	if !bytes.Equal(resp.key, expectedResponse.key) {
 		t.Errorf("Expected key to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.key), string(resp.key))
 	}
-	if bytes.Compare(resp.value, expectedResponse.value) != 0 {
+	if !bytes.Equal(resp.value, expectedResponse.value) {
 		t.Errorf("Expected value to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.value), string(resp.value))
 	}
@@ -521,6 +528,8 @@ func TestKeys(t *testing.T) {
 		}
 	}()
 	defer server.Close()
+
+	time.Sleep(500 * time.Millisecond)
 
 	expectedResponse := response{
 		command: []byte("KEYS"),
@@ -558,15 +567,15 @@ func TestKeys(t *testing.T) {
 		t.Errorf("Expected ok to be \"%v\", got \"%v\" instead",
 			expectedResponse.ok, resp.ok)
 	}
-	if bytes.Compare(resp.command, expectedResponse.command) != 0 {
+	if !bytes.Equal(resp.command, expectedResponse.command) {
 		t.Errorf("Expected command to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.command), string(resp.command))
 	}
-	if bytes.Compare(resp.message, expectedResponse.message) != 0 {
+	if !bytes.Equal(resp.message, expectedResponse.message) {
 		t.Errorf("Expected message to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.message), string(resp.message))
 	}
-	if bytes.Compare(resp.key, expectedResponse.key) != 0 {
+	if !bytes.Equal(resp.key, expectedResponse.key) {
 		t.Errorf("Expected key to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.key), string(resp.key))
 	}
@@ -592,6 +601,8 @@ func TestPing(t *testing.T) {
 		}
 	}()
 	defer server.Close()
+
+	time.Sleep(500 * time.Millisecond)
 
 	expectedResponse := response{
 		command: []byte("PING"),
@@ -623,19 +634,19 @@ func TestPing(t *testing.T) {
 		t.Errorf("Expected ok to be \"%v\", got \"%v\" instead",
 			expectedResponse.ok, resp.ok)
 	}
-	if bytes.Compare(resp.command, expectedResponse.command) != 0 {
+	if !bytes.Equal(resp.command, expectedResponse.command) {
 		t.Errorf("Expected command to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.command), string(resp.command))
 	}
-	if bytes.Compare(resp.message, expectedResponse.message) != 0 {
+	if !bytes.Equal(resp.message, expectedResponse.message) {
 		t.Errorf("Expected message to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.message), string(resp.message))
 	}
-	if bytes.Compare(resp.key, expectedResponse.key) != 0 {
+	if !bytes.Equal(resp.key, expectedResponse.key) {
 		t.Errorf("Expected key to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.key), string(resp.key))
 	}
-	if bytes.Compare(resp.value, expectedResponse.value) != 0 {
+	if !bytes.Equal(resp.value, expectedResponse.value) {
 		t.Errorf("Expected value to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.value), string(resp.value))
 	}
@@ -650,6 +661,8 @@ func TestClose(t *testing.T) {
 		}
 	}()
 	defer server.Close()
+
+	time.Sleep(500 * time.Millisecond)
 
 	expectedResponse := response{
 		command: []byte("CLOSE"),
@@ -681,19 +694,19 @@ func TestClose(t *testing.T) {
 		t.Errorf("Expected ok to be \"%v\", got \"%v\" instead",
 			expectedResponse.ok, resp.ok)
 	}
-	if bytes.Compare(resp.command, expectedResponse.command) != 0 {
+	if !bytes.Equal(resp.command, expectedResponse.command) {
 		t.Errorf("Expected command to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.command), string(resp.command))
 	}
-	if bytes.Compare(resp.message, expectedResponse.message) != 0 {
+	if !bytes.Equal(resp.message, expectedResponse.message) {
 		t.Errorf("Expected message to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.message), string(resp.message))
 	}
-	if bytes.Compare(resp.key, expectedResponse.key) != 0 {
+	if !bytes.Equal(resp.key, expectedResponse.key) {
 		t.Errorf("Expected key to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.key), string(resp.key))
 	}
-	if bytes.Compare(resp.value, expectedResponse.value) != 0 {
+	if !bytes.Equal(resp.value, expectedResponse.value) {
 		t.Errorf("Expected value to be \"%s\", got \"%s\" instead",
 			string(expectedResponse.value), string(resp.value))
 	}


### PR DESCRIPTION
## Features

- Add NewCacheMapWithCleanup(interval) that creates a CacheMap with cleanup routine.
- Add CacheMap.SetEx() method that stores an item with expiry time.

## Improvements

- Tests

## Build

- Update Go version to 1.19
- Update direct and transitive dependencies
- Makefile improvements