### PR TITLE
Cache Improvements

### DIFF
--- a/internal/cache/map.go
+++ b/internal/cache/map.go
@@ -42,9 +42,13 @@ func (cm *CacheMap) Set(key string, value []byte) {
 
 // SetEx sets given value for the given key, and an expiration time.
 // Overwrites the previous value for the key.
-func (cm *CacheMap) SetEx(key string, value []byte, expires int64) {
+func (cm *CacheMap) SetEx(key string, value []byte, expires time.Duration) {
+	var expirationInNano int64
+	if expires > 0 {
+		expirationInNano = time.Now().Add(expires).UnixNano()
+	}
 	cm.mu.Lock()
-	cm.items[key] = item{data: value, expires: expires}
+	cm.items[key] = item{data: value, expires: expirationInNano}
 	cm.mu.Unlock()
 }
 

--- a/internal/cache/map_test.go
+++ b/internal/cache/map_test.go
@@ -65,8 +65,8 @@ func TestSetEx(t *testing.T) {
 	cmap := NewCacheMap()
 	key := "key1"
 	value := []byte("value1")
-	expires := int64(1668819947000)
-	cmap.SetEx(key, value, expires)
+	expectedExp := time.Now().Add(1000 * time.Millisecond).UnixNano()
+	cmap.SetEx(key, value, 1000*time.Millisecond)
 
 	retrieved, ok := cmap.items[key]
 	if !ok {
@@ -75,8 +75,8 @@ func TestSetEx(t *testing.T) {
 	if !bytes.Equal(retrieved.data, value) {
 		t.Error("Retrieved value is not the same")
 	}
-	if retrieved.expires != expires {
-		t.Error("Stored expires time does not match the given value")
+	if time.Duration(retrieved.expires).Milliseconds() != time.Duration(expectedExp).Milliseconds() {
+		t.Error("Stored expires time does not match expected value")
 	}
 }
 
@@ -186,5 +186,30 @@ func TestKeys(t *testing.T) {
 		if keys[i] != expectedKeys[i] {
 			t.Errorf("Keys do not match the expected ones")
 		}
+	}
+}
+
+func TestCleanup(t *testing.T) {
+	cmap := NewCacheMapWithCleanup(1 * time.Millisecond)
+	noExpiration := time.Duration(0)
+	shouldExpire := 25 * time.Millisecond
+	shouldNotExpire := 150 * time.Millisecond
+
+	cmap.SetEx("key1", []byte("value1"), noExpiration)
+	cmap.SetEx("key2", []byte("value2"), shouldExpire)
+	cmap.SetEx("key3", []byte("value3"), shouldNotExpire)
+
+	<-time.After(30 * time.Millisecond)
+	_, ok := cmap.Get("key1")
+	if !ok {
+		t.Errorf("Expected \"key1\" to be present, didn't find it instead")
+	}
+	_, ok = cmap.Get("key2")
+	if ok {
+		t.Errorf("Expected \"key2\" to be deleted, found it instead")
+	}
+	_, ok = cmap.Get("key3")
+	if !ok {
+		t.Errorf("Expected \"key3\" to be present, didn't find it instead")
 	}
 }


### PR DESCRIPTION
## Changes

- Improve `cache` pkg coverage
- SetEx accepts time.Duration instead of int64 as expires param